### PR TITLE
[VL] Add experimental Kafka streaming read support

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -655,5 +655,31 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>kafka</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.gluten</groupId>
+          <artifactId>gluten-kafka</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.gluten</groupId>
+          <artifactId>gluten-kafka</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql-kafka-0-10_${scala.binary.version}</artifactId>
+          <version>${spark.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/backends-velox/src-kafka/test/scala/org/apache/gluten/execution/kafka/VeloxGlutenKafkaScanSuite.scala
+++ b/backends-velox/src-kafka/test/scala/org/apache/gluten/execution/kafka/VeloxGlutenKafkaScanSuite.scala
@@ -18,10 +18,11 @@ package org.apache.gluten.execution.kafka
 
 import org.apache.gluten.execution.{MicroBatchScanExecTransformer, VeloxWholeStageTransformerSuite}
 
-import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.streaming.StreamingQueryWrapper
 import org.apache.spark.sql.streaming.Trigger
+
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 
 import java.util.{Collections, Properties}
 
@@ -29,8 +30,8 @@ import scala.concurrent.duration.DurationInt
 
 /**
  * Kafka streaming read tests for the Velox backend. Requires the native library to be built with
- * ENABLE_KAFKA and a running Kafka broker, reachable at localhost:9092 by default or at the
- * address given by the KAFKA_BOOTSTRAP_SERVERS environment variable.
+ * ENABLE_KAFKA and a running Kafka broker, reachable at localhost:9092 by default or at the address
+ * given by the KAFKA_BOOTSTRAP_SERVERS environment variable.
  */
 class VeloxGlutenKafkaScanSuite
   extends VeloxWholeStageTransformerSuite

--- a/backends-velox/src-kafka/test/scala/org/apache/gluten/execution/kafka/VeloxGlutenKafkaScanSuite.scala
+++ b/backends-velox/src-kafka/test/scala/org/apache/gluten/execution/kafka/VeloxGlutenKafkaScanSuite.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution.kafka
+
+import org.apache.gluten.execution.{MicroBatchScanExecTransformer, VeloxWholeStageTransformerSuite}
+
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.streaming.StreamingQueryWrapper
+import org.apache.spark.sql.streaming.Trigger
+
+import java.util.{Collections, Properties}
+
+import scala.concurrent.duration.DurationInt
+
+/**
+ * Kafka streaming read tests for the Velox backend. Requires the native library to be built with
+ * ENABLE_KAFKA and a running Kafka broker, reachable at localhost:9092 by default or at the
+ * address given by the KAFKA_BOOTSTRAP_SERVERS environment variable.
+ */
+class VeloxGlutenKafkaScanSuite
+  extends VeloxWholeStageTransformerSuite
+  with GlutenKafkaScanSuite {
+
+  override protected val resourcePath: String = "/tpch-data-parquet"
+  override protected val fileFormat: String = "parquet"
+
+  override protected val kafkaBootstrapServers: String =
+    sys.env.getOrElse("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .set("spark.sql.shuffle.partitions", "2")
+  }
+
+  private def withTopic(topicName: String)(func: => Unit): Unit = {
+    val props = new Properties()
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServers)
+    val adminClient = AdminClient.create(props)
+    try {
+      if (adminClient.listTopics().names().get().contains(topicName)) {
+        adminClient.deleteTopics(Collections.singletonList(topicName)).all().get()
+      }
+      adminClient
+        .createTopics(Collections.singletonList(new NewTopic(topicName, 1, 1.toShort)))
+        .all()
+        .get()
+      func
+    } finally {
+      try {
+        if (adminClient.listTopics().names().get().contains(topicName)) {
+          adminClient.deleteTopics(Collections.singletonList(topicName)).all().get()
+        }
+      } catch {
+        case _: Exception => logWarning(s"Delete topic $topicName failed.")
+      }
+      adminClient.close()
+    }
+  }
+
+  test("kafka streaming read offloads to native and returns consistent data") {
+    withTempDir {
+      dir =>
+        val topic = "velox_kafka_read"
+        val tableName = "velox_kafka_read_sink"
+        withTable(tableName) {
+          withTopic(topic) {
+            spark.sql(s"""
+                         |CREATE EXTERNAL TABLE $tableName (
+                         |    id int
+                         |) USING parquet
+                         |LOCATION '${dir.getCanonicalPath}'
+                         |""".stripMargin)
+
+            spark
+              .range(1000)
+              .selectExpr("cast(id as string) as value")
+              .write
+              .format("kafka")
+              .option("kafka.bootstrap.servers", kafkaBootstrapServers)
+              .option("topic", topic)
+              .save()
+
+            val streamQuery = spark.readStream
+              .format("kafka")
+              .option("kafka.bootstrap.servers", kafkaBootstrapServers)
+              .option("subscribe", topic)
+              .option("startingOffsets", "earliest")
+              .load()
+              .selectExpr("cast(cast(value as string) as int) as id")
+              .writeStream
+              .format("parquet")
+              .option("checkpointLocation", dir.getCanonicalPath + "/_checkpoint")
+              .trigger(Trigger.ProcessingTime("1 seconds"))
+              .start(dir.getCanonicalPath)
+
+            try {
+              eventually(timeout(60.seconds), interval(5.seconds)) {
+                // The Kafka scan must be offloaded to the native micro-batch scan.
+                val scans = streamQuery
+                  .asInstanceOf[StreamingQueryWrapper]
+                  .streamingQuery
+                  .lastExecution
+                  .executedPlan
+                  .collect { case p: MicroBatchScanExecTransformer => p }
+                assert(scans.size == 1)
+
+                val result =
+                  spark.sql(s"SELECT count(id), min(id), max(id) FROM $tableName").collect()
+                assert(result.length == 1)
+                assert(result.head.getLong(0) == 1000)
+                assert(result.head.getInt(1) == 0)
+                assert(result.head.getInt(2) == 999)
+              }
+            } finally {
+              streamQuery.stop()
+            }
+          }
+        }
+    }
+  }
+}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -55,6 +55,7 @@ option(ENABLE_S3 "Enable S3" OFF)
 option(ENABLE_HDFS "Enable HDFS" OFF)
 option(ENABLE_ORC "Enable ORC" OFF)
 option(ENABLE_ABFS "Enable ABFS" OFF)
+option(ENABLE_KAFKA "Enable Kafka streaming read" OFF)
 option(ENABLE_GPU "Enable GPU" OFF)
 option(ENABLE_ENHANCED_FEATURES "Enable enhanced features" OFF)
 

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -218,6 +218,11 @@ if(ENABLE_S3)
   find_package(ZLIB)
 endif()
 
+if(ENABLE_KAFKA)
+  list(APPEND VELOX_SRCS operators/reader/KafkaReader.cc
+       operators/reader/KafkaConnector.cc)
+endif()
+
 if(ENABLE_GPU)
   list(
     APPEND
@@ -484,6 +489,34 @@ else()
   import_library(external::simdjson
                  ${VELOX_BUILD_PATH}/_deps/simdjson-build/libsimdjson.a)
   target_link_libraries(velox PUBLIC external::simdjson)
+endif()
+
+# Find and link librdkafka for Kafka streaming support
+if(ENABLE_KAFKA)
+  add_definitions(-DENABLE_KAFKA)
+  find_package(RdKafka CONFIG)
+  if(RdKafka_FOUND AND TARGET RdKafka::rdkafka++)
+    message(STATUS "Found RdKafka: ${RdKafka_DIR}")
+    target_link_libraries(velox PUBLIC RdKafka::rdkafka++)
+  else()
+    # Try to find librdkafka using pkg-config
+    find_package(PkgConfig)
+    if(PKG_CONFIG_FOUND)
+      pkg_check_modules(RDKAFKA QUIET rdkafka++)
+      if(RDKAFKA_FOUND)
+        message(STATUS "Found librdkafka via pkg-config: ${RDKAFKA_LIBRARIES}")
+        target_include_directories(velox PUBLIC ${RDKAFKA_INCLUDE_DIRS})
+        target_link_libraries(velox PUBLIC ${RDKAFKA_LIBRARIES})
+      else()
+        message(FATAL_ERROR "ENABLE_KAFKA is ON but librdkafka was not found.")
+      endif()
+    else()
+      message(
+        FATAL_ERROR
+          "ENABLE_KAFKA is ON but pkg-config was not found to locate librdkafka."
+      )
+    endif()
+  endif()
 endif()
 
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -26,6 +26,10 @@
 #include "operators/plannodes/RowVectorStream.h"
 #include "utils/ConfigExtractor.h"
 
+#ifdef ENABLE_KAFKA
+#include "operators/reader/KafkaConnector.h"
+#endif
+
 #ifdef GLUTEN_ENABLE_QAT
 #include "utils/qat/QatCodec.h"
 #endif
@@ -420,6 +424,13 @@ std::shared_ptr<facebook::velox::connector::Connector> VeloxBackend::createValue
     bool dynamicFilterEnabled) const {
   return std::make_shared<ValueStreamConnector>(connectorId, hiveConnectorConfig_, dynamicFilterEnabled);
 }
+
+#ifdef ENABLE_KAFKA
+std::shared_ptr<facebook::velox::connector::Connector> VeloxBackend::createKafkaConnector(
+    const std::string& connectorId) const {
+  return std::make_shared<KafkaConnector>(connectorId, hiveConnectorConfig_);
+}
+#endif
 
 #ifdef GLUTEN_ENABLE_GPU
 std::shared_ptr<facebook::velox::connector::Connector> VeloxBackend::createCudfHiveConnector(

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -89,6 +89,10 @@ class VeloxBackend {
       const std::string& connectorId,
       bool dynamicFilterEnabled) const;
 
+#ifdef ENABLE_KAFKA
+  std::shared_ptr<facebook::velox::connector::Connector> createKafkaConnector(const std::string& connectorId) const;
+#endif
+
 #ifdef GLUTEN_ENABLE_GPU
   std::shared_ptr<facebook::velox::connector::Connector> createCudfHiveConnector(
       const std::string& connectorId,

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -230,6 +230,7 @@ VeloxConnectorIds makeScopedConnectorIds(uint64_t runtimeId) {
       .iceberg = makeScopedConnectorId(kIcebergConnectorId, runtimeId),
       .delta = makeScopedConnectorId(delta::DeltaConnectorFactory::kDeltaConnectorName, runtimeId),
       .iterator = makeScopedConnectorId(kIteratorConnectorId, runtimeId),
+      .kafka = makeScopedConnectorId(kKafkaConnectorId, runtimeId),
       .cudfHive = makeScopedConnectorId(kCudfHiveConnectorId, runtimeId)};
 }
 
@@ -316,6 +317,15 @@ void VeloxRuntime::registerConnectors() {
       velox::connector::hasConnector(connectorIds_.iterator),
       "Scoped iterator connector not found after registration: " + connectorIds_.iterator);
 
+#ifdef ENABLE_KAFKA
+  connectorIds_.kafkaRegistered =
+      velox::connector::registerConnector(backend->createKafkaConnector(connectorIds_.kafka));
+  GLUTEN_CHECK(connectorIds_.kafkaRegistered, "Failed to register scoped Kafka connector: " + connectorIds_.kafka);
+  GLUTEN_CHECK(
+      velox::connector::hasConnector(connectorIds_.kafka),
+      "Scoped Kafka connector not found after registration: " + connectorIds_.kafka);
+#endif
+
 #ifdef GLUTEN_ENABLE_GPU
   if (veloxCfg_->get<bool>(kCudfEnableTableScan, kCudfEnableTableScanDefault) &&
       veloxCfg_->get<bool>(kCudfEnabled, kCudfEnabledDefault)) {
@@ -335,6 +345,12 @@ void VeloxRuntime::unregisterConnectors() {
   if (connectorIds_.cudfHiveRegistered) {
     velox::connector::unregisterConnector(connectorIds_.cudfHive);
     connectorIds_.cudfHiveRegistered = false;
+  }
+#endif
+#ifdef ENABLE_KAFKA
+  if (connectorIds_.kafkaRegistered) {
+    velox::connector::unregisterConnector(connectorIds_.kafka);
+    connectorIds_.kafkaRegistered = false;
   }
 #endif
   if (connectorIds_.iteratorRegistered) {

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -133,6 +133,7 @@ const uint64_t kVeloxMemReclaimMaxWaitMsDefault = 3600000; // 60min
 
 const std::string kHiveConnectorId = "test-hive";
 const std::string kIcebergConnectorId = "test-iceberg";
+const std::string kKafkaConnectorId = "kafka-stream";
 
 const std::string kVeloxCacheEnabled = "spark.gluten.sql.columnar.backend.velox.cacheEnabled";
 

--- a/cpp/velox/operators/reader/KAFKA_INTEGRATION.md
+++ b/cpp/velox/operators/reader/KAFKA_INTEGRATION.md
@@ -1,0 +1,238 @@
+# Kafka Reader Integration Guide
+
+## Overview
+
+This document explains how Kafka streams are mapped to use the KafkaReader in the Gluten Velox backend. The integration allows reading streaming data from Kafka topics through the Substrait plan.
+
+Kafka support is disabled by default. Build with `--enable_kafka=ON` (which sets the `ENABLE_KAFKA` CMake option and, with `--enable_vcpkg=ON`, installs the `velox-kafka` vcpkg feature providing librdkafka).
+
+## Architecture
+
+### Components
+
+1. **KafkaSplit** (`KafkaSplit.h`) - Connector split containing Kafka connection parameters
+2. **KafkaConnector** (`KafkaConnector.h/cc`) - Velox connector for Kafka streams
+3. **KafkaReader** (`KafkaReader.h/cc`) - Source operator that reads from Kafka using librdkafka
+4. **SubstraitToVeloxPlan** - Modified to handle `stream_kafka()` in ReadRel
+
+### Flow
+
+```
+Substrait ReadRel (stream_kafka=true)
+    ↓
+SubstraitToVeloxPlanConverter::toVeloxPlan()
+    ↓
+constructKafkaStreamNode()
+    ↓
+TableScanNode with kKafkaConnectorId
+    ↓
+KafkaSplit created with broker/topic/partition info
+    ↓
+KafkaReader operator consumes messages
+    ↓
+RowVector output
+```
+
+## Key Changes
+
+### 1. SubstraitToVeloxPlan.cc
+
+The `getStreamIndex()` method now returns -1 for Kafka streams, but they are handled specially:
+
+```cpp
+// Line 1684-1690
+int32_t SubstraitToVeloxPlanConverter::getStreamIndex(const ::substrait::ReadRel& sRead) {
+  // Check if this is a Kafka stream
+  if (sRead.stream_kafka()) {
+    // For Kafka streams, we don't use the iterator pattern
+    // Return -1 to indicate this should be handled as a regular scan
+    return -1;
+  }
+  // ... rest of the method
+}
+```
+
+In `toVeloxPlan()`, Kafka streams are now detected and routed to `constructKafkaStreamNode()`:
+
+```cpp
+// Line 1440-1452
+core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::ReadRel& readRel) {
+  // ... validation code ...
+  
+  // Check if this is a Kafka stream - handle it specially
+  if (readRel.stream_kafka()) {
+    return constructKafkaStreamNode(readRel);
+  }
+  
+  // ... rest of the method for regular streams and table scans ...
+}
+```
+
+### 2. Connector Registration
+
+In `VeloxBackend.cc`, the Kafka connector is registered alongside Hive and ValueStream connectors:
+
+```cpp
+// Register Kafka connector for streaming data from Kafka topics
+velox::connector::registerConnector(
+    std::make_shared<gluten::KafkaConnector>(kKafkaConnectorId, hiveConf));
+```
+
+### 3. Split Creation
+
+When creating splits for Kafka streams, use `KafkaConnectorSplit`:
+
+```cpp
+auto kafkaSplit = std::make_shared<gluten::KafkaConnectorSplit>(
+    kKafkaConnectorId,
+    "localhost:9092",           // brokers
+    "my-topic",                 // topic
+    0,                          // partition
+    0,                          // startOffset
+    -1,                         // endOffset (-1 for latest)
+    "my-consumer-group",        // groupId
+    additionalProps             // additional Kafka properties
+);
+```
+
+## Usage Example
+
+### From Substrait Plan
+
+When a Substrait ReadRel has `stream_kafka()` set to true, it will automatically:
+
+1. Create a TableScanNode with `kKafkaConnectorId`
+2. Extract schema from `base_schema`
+3. Create appropriate column handles
+4. Mark the split info as `TABLE_SCAN` type
+
+### Creating Kafka Splits Programmatically
+
+```cpp
+#include "operators/reader/KafkaSplit.h"
+
+// Create Kafka split
+std::unordered_map<std::string, std::string> kafkaProps;
+kafkaProps["auto.offset.reset"] = "earliest";
+kafkaProps["enable.auto.commit"] = "false";
+
+auto split = std::make_shared<gluten::KafkaConnectorSplit>(
+    kKafkaConnectorId,
+    "broker1:9092,broker2:9092",  // Kafka brokers
+    "events-topic",                // Topic name
+    0,                             // Partition number
+    100,                           // Start offset
+    1000,                          // End offset
+    "gluten-consumer",             // Consumer group ID
+    kafkaProps                     // Additional properties
+);
+
+// Add split to task
+task->addSplit(planNodeId, std::move(split));
+```
+
+### Kafka Message Schema
+
+The KafkaReader produces RowVectors with the following default schema:
+
+- Column 0: `key` (VARBINARY) - Message key
+- Column 1: `value` (VARBINARY) - Message payload
+- Column 2: `topic` (VARCHAR) - Topic name
+- Column 3: `partition` (INTEGER) - Partition number
+- Column 4: `offset` (BIGINT) - Message offset
+- Column 5: `timestamp` (BIGINT) - Message timestamp
+
+You can customize the schema in the Substrait ReadRel's `base_schema`.
+
+## Configuration
+
+### Kafka Consumer Properties
+
+Configure Kafka consumer through `KafkaReaderConfig`:
+
+```cpp
+config_.brokers = "localhost:9092";
+config_.topic = "my-topic";
+config_.partition = 0;
+config_.startOffset = 0;
+config_.endOffset = -1;  // Read until latest
+config_.groupId = "my-group";
+config_.maxPollRecords = 1000;
+config_.pollTimeoutMs = 1000;
+config_.additionalProps["security.protocol"] = "SASL_SSL";
+```
+
+### Velox Configuration
+
+Add to your Velox configuration:
+
+```cpp
+const std::string kKafkaConnectorId = "kafka-stream";
+```
+
+## Implementation Details
+
+### KafkaReader Operator
+
+The `KafkaReader` is a `SourceOperator` that:
+
+1. Initializes librdkafka consumer on first `getOutput()` call
+2. Polls messages in batches (configurable via `maxPollRecords`)
+3. Converts Kafka messages to Velox RowVectors
+4. Manages offset commits
+5. Handles partition EOF and errors
+
+### Offset Management
+
+- Offsets are committed after each batch
+- Manual offset management (auto-commit disabled)
+- Supports reading from specific offset ranges
+- Handles partition EOF gracefully
+
+### Error Handling
+
+- Connection errors logged and operator marked as finished
+- Message-level errors logged but don't stop processing
+- Timeout errors handled gracefully (returns empty batch)
+
+## Limitations and Future Work
+
+1. **Single Partition**: Currently reads from one partition per split
+2. **No Rebalancing**: Manual partition assignment (no consumer group rebalancing)
+3. **Schema**: Fixed schema mapping (could be made configurable)
+4. **Deserialization**: Messages returned as raw bytes (no built-in Avro/JSON support)
+
+## Testing
+
+To test the Kafka integration:
+
+1. Start a Kafka broker
+2. Create a test topic with data
+3. Create a Substrait plan with `stream_kafka()` set
+4. Execute the plan through Gluten
+
+Example test setup:
+
+```bash
+# Start Kafka
+docker run -d --name kafka -p 9092:9092 apache/kafka
+
+# Create topic
+kafka-topics --create --topic test-topic --bootstrap-server localhost:9092
+
+# Produce test data
+echo "test message" | kafka-console-producer --topic test-topic --bootstrap-server localhost:9092
+```
+
+## Dependencies
+
+- librdkafka (C/C++ Kafka client library)
+- Velox connector framework
+- Substrait plan support
+
+## See Also
+
+- `KafkaReader.h` - Main reader implementation
+- `KafkaSplit.h` - Split definition
+- `KafkaConnector.h` - Connector interface
+- `SubstraitToVeloxPlan.cc` - Plan conversion logic

--- a/cpp/velox/operators/reader/KafkaConnector.cc
+++ b/cpp/velox/operators/reader/KafkaConnector.cc
@@ -20,8 +20,7 @@
 
 namespace gluten {
 
-std::unique_ptr<facebook::velox::exec::SourceOperator> 
-KafkaDataSourceFactory::createKafkaReader(
+std::unique_ptr<facebook::velox::exec::SourceOperator> KafkaDataSourceFactory::createKafkaReader(
     int32_t operatorId,
     facebook::velox::exec::DriverCtx* driverCtx,
     const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode) {

--- a/cpp/velox/operators/reader/KafkaConnector.cc
+++ b/cpp/velox/operators/reader/KafkaConnector.cc
@@ -15,25 +15,19 @@
  * limitations under the License.
  */
 
-#pragma once
-
-#include <string>
+#include "KafkaConnector.h"
+#include "KafkaReader.h"
 
 namespace gluten {
 
-struct VeloxConnectorIds {
-  std::string hive;
-  std::string iceberg;
-  std::string delta;
-  std::string iterator;
-  std::string kafka;
-  std::string cudfHive;
-  bool hiveRegistered{false};
-  bool icebergRegistered{false};
-  bool deltaRegistered{false};
-  bool iteratorRegistered{false};
-  bool kafkaRegistered{false};
-  bool cudfHiveRegistered{false};
-};
+std::unique_ptr<facebook::velox::exec::SourceOperator> 
+KafkaDataSourceFactory::createKafkaReader(
+    int32_t operatorId,
+    facebook::velox::exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode) {
+  return std::make_unique<KafkaReader>(operatorId, driverCtx, planNode);
+}
 
 } // namespace gluten
+
+// Made with Bob

--- a/cpp/velox/operators/reader/KafkaConnector.h
+++ b/cpp/velox/operators/reader/KafkaConnector.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/exec/Operator.h"
+
+namespace gluten {
+
+/// Kafka connector for streaming data from Kafka topics
+class KafkaConnector : public facebook::velox::connector::Connector {
+ public:
+  explicit KafkaConnector(
+      const std::string& id,
+      std::shared_ptr<const facebook::velox::config::ConfigBase> config)
+      : Connector(id), config_(std::move(config)) {}
+
+  std::unique_ptr<facebook::velox::connector::DataSource> createDataSource(
+      const facebook::velox::RowTypePtr& outputType,
+      const facebook::velox::connector::ConnectorTableHandlePtr& tableHandle,
+      const facebook::velox::connector::ColumnHandleMap& columnHandles,
+      facebook::velox::connector::ConnectorQueryCtx* connectorQueryCtx) override {
+    VELOX_UNSUPPORTED("KafkaConnector does not support createDataSource");
+  }
+
+  std::unique_ptr<facebook::velox::connector::DataSink> createDataSink(
+      facebook::velox::RowTypePtr inputType,
+      facebook::velox::connector::ConnectorInsertTableHandlePtr connectorInsertTableHandle,
+      facebook::velox::connector::ConnectorQueryCtx* connectorQueryCtx,
+      facebook::velox::connector::CommitStrategy commitStrategy) override {
+    VELOX_UNSUPPORTED("KafkaConnector does not support createDataSink");
+  }
+
+  const std::shared_ptr<const facebook::velox::config::ConfigBase>& getConfig() const {
+    return config_;
+  }
+
+ private:
+  std::shared_ptr<const facebook::velox::config::ConfigBase> config_;
+};
+
+/// Factory for creating Kafka data sources
+/// This is used by the Velox execution engine to create KafkaReader operators
+class KafkaDataSourceFactory {
+ public:
+  static std::unique_ptr<facebook::velox::exec::SourceOperator> createKafkaReader(
+      int32_t operatorId,
+      facebook::velox::exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode);
+};
+
+} // namespace gluten
+
+// Made with Bob

--- a/cpp/velox/operators/reader/KafkaConnector.h
+++ b/cpp/velox/operators/reader/KafkaConnector.h
@@ -25,9 +25,7 @@ namespace gluten {
 /// Kafka connector for streaming data from Kafka topics
 class KafkaConnector : public facebook::velox::connector::Connector {
  public:
-  explicit KafkaConnector(
-      const std::string& id,
-      std::shared_ptr<const facebook::velox::config::ConfigBase> config)
+  explicit KafkaConnector(const std::string& id, std::shared_ptr<const facebook::velox::config::ConfigBase> config)
       : Connector(id), config_(std::move(config)) {}
 
   std::unique_ptr<facebook::velox::connector::DataSource> createDataSource(

--- a/cpp/velox/operators/reader/KafkaReader.cc
+++ b/cpp/velox/operators/reader/KafkaReader.cc
@@ -1,0 +1,462 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "KafkaReader.h"
+#include "KafkaSplit.h"
+#include <glog/logging.h>
+#include "velox/vector/FlatVector.h"
+
+namespace gluten {
+
+namespace {
+
+// Event callback for Kafka consumer
+class KafkaEventCb : public RdKafka::EventCb {
+ public:
+  void event_cb(RdKafka::Event& event) override {
+    switch (event.type()) {
+      case RdKafka::Event::EVENT_ERROR:
+        LOG(ERROR) << "Kafka error: " << RdKafka::err2str(event.err()) 
+                   << " - " << event.str();
+        break;
+      case RdKafka::Event::EVENT_STATS:
+        LOG(INFO) << "Kafka stats: " << event.str();
+        break;
+      case RdKafka::Event::EVENT_LOG:
+        LOG(INFO) << "Kafka log: " << event.str();
+        break;
+      default:
+        LOG(INFO) << "Kafka event: " << event.type() << " - " << event.str();
+        break;
+    }
+  }
+};
+
+// Rebalance callback for consumer group
+class KafkaRebalanceCb : public RdKafka::RebalanceCb {
+ public:
+  void rebalance_cb(
+      RdKafka::KafkaConsumer* consumer,
+      RdKafka::ErrorCode err,
+      std::vector<RdKafka::TopicPartition*>& partitions) override {
+    if (err == RdKafka::ERR__ASSIGN_PARTITIONS) {
+      LOG(INFO) << "Kafka rebalance: assigning " << partitions.size() << " partitions";
+      consumer->assign(partitions);
+    } else if (err == RdKafka::ERR__REVOKE_PARTITIONS) {
+      LOG(INFO) << "Kafka rebalance: revoking " << partitions.size() << " partitions";
+      consumer->unassign();
+    } else {
+      LOG(ERROR) << "Kafka rebalance error: " << RdKafka::err2str(err);
+      consumer->unassign();
+    }
+  }
+};
+
+} // anonymous namespace
+
+KafkaReader::KafkaReader(
+    int32_t operatorId,
+    facebook::velox::exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode)
+    : SourceOperator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "KafkaReader") {
+  LOG(INFO) << "KafkaReader created with operator ID: " << operatorId;
+}
+
+KafkaReader::~KafkaReader() {
+  cleanup();
+}
+
+void KafkaReader::initializeConsumer() {
+  if (consumerInitialized_) {
+    return;
+  }
+
+  std::string errstr;
+
+  // Create global configuration
+  conf_.reset(RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
+  if (!conf_) {
+    throw std::runtime_error("Failed to create Kafka global configuration");
+  }
+
+  // Set broker list
+  if (conf_->set("bootstrap.servers", config_.brokers, errstr) != RdKafka::Conf::CONF_OK) {
+    throw std::runtime_error("Failed to set bootstrap.servers: " + errstr);
+  }
+
+  // Set group ID if provided
+  if (!config_.groupId.empty()) {
+    if (conf_->set("group.id", config_.groupId, errstr) != RdKafka::Conf::CONF_OK) {
+      throw std::runtime_error("Failed to set group.id: " + errstr);
+    }
+  }
+
+  // Set event callback
+  static KafkaEventCb eventCb;
+  if (conf_->set("event_cb", &eventCb, errstr) != RdKafka::Conf::CONF_OK) {
+    LOG(WARNING) << "Failed to set event callback: " << errstr;
+  }
+
+  // Set rebalance callback
+  static KafkaRebalanceCb rebalanceCb;
+  if (conf_->set("rebalance_cb", &rebalanceCb, errstr) != RdKafka::Conf::CONF_OK) {
+    LOG(WARNING) << "Failed to set rebalance callback: " << errstr;
+  }
+
+  // Disable auto-commit for manual offset management
+  if (conf_->set("enable.auto.commit", "false", errstr) != RdKafka::Conf::CONF_OK) {
+    LOG(WARNING) << "Failed to disable auto-commit: " << errstr;
+  }
+
+  // Set additional properties
+  for (const auto& [key, value] : config_.additionalProps) {
+    if (conf_->set(key, value, errstr) != RdKafka::Conf::CONF_OK) {
+      LOG(WARNING) << "Failed to set property " << key << ": " << errstr;
+    }
+  }
+
+  // Create consumer
+  consumer_.reset(RdKafka::KafkaConsumer::create(conf_.get(), errstr));
+  if (!consumer_) {
+    throw std::runtime_error("Failed to create Kafka consumer: " + errstr);
+  }
+
+  consumerInitialized_ = true;
+  LOG(INFO) << "Kafka consumer initialized successfully";
+}
+
+void KafkaReader::connectToKafka() {
+  if (!consumerInitialized_) {
+    initializeConsumer();
+  }
+
+  // Create topic partition for assignment
+  std::vector<RdKafka::TopicPartition*> partitions;
+  RdKafka::TopicPartition* partition = 
+      RdKafka::TopicPartition::create(config_.topic, config_.partition, config_.startOffset);
+  partitions.push_back(partition);
+
+  // Assign partition
+  RdKafka::ErrorCode err = consumer_->assign(partitions);
+  if (err != RdKafka::ERR_NO_ERROR) {
+    delete partition;
+    throw std::runtime_error("Failed to assign partition: " + RdKafka::err2str(err));
+  }
+
+  currentOffset_ = config_.startOffset;
+  LOG(INFO) << "Connected to Kafka topic: " << config_.topic 
+            << ", partition: " << config_.partition
+            << ", start offset: " << config_.startOffset;
+
+  delete partition;
+}
+
+std::vector<RdKafka::Message*> KafkaReader::pollMessages() {
+  std::vector<RdKafka::Message*> messages;
+  
+  if (!consumer_) {
+    return messages;
+  }
+
+  int32_t remainingRecords = config_.maxPollRecords;
+  auto startTime = std::chrono::steady_clock::now();
+  
+  while (remainingRecords > 0) {
+    // Check if we've exceeded the poll timeout
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - startTime).count();
+    if (elapsed >= config_.pollTimeoutMs) {
+      break;
+    }
+
+    // Poll for a single message
+    RdKafka::Message* msg = consumer_->consume(100); // 100ms timeout per consume
+    
+    if (!msg) {
+      continue;
+    }
+
+    switch (msg->err()) {
+      case RdKafka::ERR_NO_ERROR:
+        // Valid message
+        messages.push_back(msg);
+        currentOffset_ = msg->offset();
+        messagesRead_++;
+        remainingRecords--;
+        
+        // Check if we've reached the end offset
+        if (config_.endOffset != RdKafka::Topic::OFFSET_END && 
+            currentOffset_ >= config_.endOffset) {
+          finished_ = true;
+          return messages;
+        }
+        break;
+
+      case RdKafka::ERR__PARTITION_EOF:
+        // End of partition
+        LOG(INFO) << "Reached end of partition at offset: " << currentOffset_;
+        delete msg;
+        finished_ = true;
+        return messages;
+
+      case RdKafka::ERR__TIMED_OUT:
+        // Timeout, no message available
+        delete msg;
+        break;
+
+      default:
+        // Error
+        LOG(ERROR) << "Kafka consume error: " << msg->errstr();
+        delete msg;
+        break;
+    }
+  }
+
+  return messages;
+}
+
+facebook::velox::RowVectorPtr KafkaReader::convertMessagesToRowVector(
+    const std::vector<RdKafka::Message*>& messages) {
+  if (messages.empty()) {
+    return nullptr;
+  }
+
+  size_t numRows = messages.size();
+
+  // Create vectors for each column
+  std::vector<facebook::velox::VectorPtr> childVectors;
+  for (size_t i = 0; i < outputType_->size(); ++i) {
+    childVectors.push_back(createColumnVector(outputType_->childAt(i), messages, i));
+  }
+
+  // Create and return RowVector
+  return std::make_shared<facebook::velox::RowVector>(
+      pool(),
+      outputType_,
+      facebook::velox::BufferPtr(nullptr),
+      numRows,
+      childVectors);
+}
+
+facebook::velox::VectorPtr KafkaReader::createColumnVector(
+    const facebook::velox::TypePtr& type,
+    const std::vector<RdKafka::Message*>& messages,
+    size_t columnIndex) {
+  size_t numRows = messages.size();
+  
+  // Handle common Kafka message fields based on column index
+  // Column 0: key (VARBINARY)
+  // Column 1: value (VARBINARY)
+  // Column 2: topic (VARCHAR)
+  // Column 3: partition (INTEGER)
+  // Column 4: offset (BIGINT)
+  // Column 5: timestamp (BIGINT)
+
+  if (type->isVarbinary() || type->isVarchar()) {
+    auto flatVector = std::dynamic_pointer_cast<facebook::velox::FlatVector<facebook::velox::StringView>>(
+        facebook::velox::BaseVector::create(type, numRows, pool()));
+    
+    for (size_t i = 0; i < numRows; ++i) {
+      const auto* msg = messages[i];
+      
+      if (columnIndex == 0) {
+        // Key
+        if (msg->key()) {
+          flatVector->set(i, facebook::velox::StringView(
+              static_cast<const char*>(msg->key()->c_str()), msg->key()->size()));
+        } else {
+          flatVector->setNull(i, true);
+        }
+      } else if (columnIndex == 1) {
+        // Value
+        if (msg->payload()) {
+          flatVector->set(i, facebook::velox::StringView(
+              static_cast<const char*>(msg->payload()), msg->len()));
+        } else {
+          flatVector->setNull(i, true);
+        }
+      } else if (columnIndex == 2) {
+        // Topic
+        const std::string topicName = msg->topic_name();
+        flatVector->set(i, facebook::velox::StringView(topicName));
+      }
+    }
+    
+    return flatVector;
+  } else if (type->isInteger()) {
+    auto flatVector = std::dynamic_pointer_cast<facebook::velox::FlatVector<int32_t>>(
+        facebook::velox::BaseVector::create(type, numRows, pool()));
+    
+    for (size_t i = 0; i < numRows; ++i) {
+      const auto* msg = messages[i];
+      
+      if (columnIndex == 3) {
+        // Partition
+        flatVector->set(i, msg->partition());
+      }
+    }
+    
+    return flatVector;
+  } else if (type->isBigint()) {
+    auto flatVector = std::dynamic_pointer_cast<facebook::velox::FlatVector<int64_t>>(
+        facebook::velox::BaseVector::create(type, numRows, pool()));
+    
+    for (size_t i = 0; i < numRows; ++i) {
+      const auto* msg = messages[i];
+      
+      if (columnIndex == 4) {
+        // Offset
+        flatVector->set(i, msg->offset());
+      } else if (columnIndex == 5) {
+        // Timestamp
+        flatVector->set(i, msg->timestamp().timestamp);
+      }
+    }
+    
+    return flatVector;
+  }
+  
+  // Default: create empty vector
+  return facebook::velox::BaseVector::create(type, numRows, pool());
+}
+
+void KafkaReader::commitOffset(int64_t offset) {
+  if (!consumer_) {
+    return;
+  }
+
+  std::vector<RdKafka::TopicPartition*> partitions;
+  RdKafka::TopicPartition* partition = 
+      RdKafka::TopicPartition::create(config_.topic, config_.partition, offset + 1);
+  partitions.push_back(partition);
+
+  RdKafka::ErrorCode err = consumer_->commitSync(partitions);
+  if (err != RdKafka::ERR_NO_ERROR) {
+    LOG(ERROR) << "Failed to commit offset: " << RdKafka::err2str(err);
+  } else {
+    LOG(INFO) << "Committed offset: " << offset;
+  }
+
+  delete partition;
+}
+
+void KafkaReader::cleanup() {
+  if (consumer_) {
+    // Commit final offset
+    if (currentOffset_ > 0) {
+      commitOffset(currentOffset_);
+    }
+    
+    // Close consumer
+    consumer_->close();
+    consumer_.reset();
+    LOG(INFO) << "Kafka consumer closed. Total messages read: " << messagesRead_;
+  }
+  
+  conf_.reset();
+  tconf_.reset();
+}
+
+facebook::velox::RowVectorPtr KafkaReader::getOutput() {
+  if (finished_ || !hasSplit_) {
+    return nullptr;
+  }
+
+  // Initialize consumer on first call
+  if (!consumerInitialized_) {
+    try {
+      connectToKafka();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to connect to Kafka: " << e.what();
+      finished_ = true;
+      return nullptr;
+    }
+  }
+
+  // Poll messages from Kafka
+  auto messages = pollMessages();
+  
+  if (messages.empty()) {
+    // No messages available, but not finished yet
+    if (!finished_) {
+      return nullptr;
+    }
+    // Finished reading
+    return nullptr;
+  }
+
+  // Convert messages to RowVector
+  auto result = convertMessagesToRowVector(messages);
+  
+  // Clean up messages
+  for (auto* msg : messages) {
+    delete msg;
+  }
+
+  // Commit offset periodically (every batch)
+  if (currentOffset_ > 0) {
+    commitOffset(currentOffset_);
+  }
+
+  return result;
+}
+
+facebook::velox::exec::BlockingReason KafkaReader::isBlocked(
+    facebook::velox::ContinueFuture* future) {
+  // Kafka consumer is non-blocking with timeout
+  return facebook::velox::exec::BlockingReason::kNotBlocked;
+}
+
+bool KafkaReader::isFinished() {
+  return (noMoreSplits_ && !hasSplit_) || finished_;
+}
+
+void KafkaReader::addSplit(
+    std::shared_ptr<facebook::velox::connector::ConnectorSplit> split) {
+  // Extract Kafka configuration from split
+  auto kafkaSplit = std::dynamic_pointer_cast<const KafkaConnectorSplit>(split);
+  if (!kafkaSplit) {
+    throw std::runtime_error("Split is not a KafkaConnectorSplit");
+  }
+  
+  hasSplit_ = true;
+  
+  // Populate config from split
+  config_.brokers = kafkaSplit->getBrokers();
+  config_.topic = kafkaSplit->getTopic();
+  config_.partition = kafkaSplit->getPartition();
+  config_.startOffset = kafkaSplit->getStartOffset();
+  config_.endOffset = kafkaSplit->getEndOffset();
+  config_.groupId = kafkaSplit->getGroupId();
+  config_.additionalProps = kafkaSplit->getAdditionalProps();
+  
+  LOG(INFO) << "Added Kafka split: " << kafkaSplit->toString();
+}
+
+void KafkaReader::noMoreSplits() {
+  noMoreSplits_ = true;
+  LOG(INFO) << "No more splits for KafkaReader";
+}
+
+} // namespace gluten
+
+// Made with Bob

--- a/cpp/velox/operators/reader/KafkaReader.cc
+++ b/cpp/velox/operators/reader/KafkaReader.cc
@@ -16,8 +16,8 @@
  */
 
 #include "KafkaReader.h"
-#include "KafkaSplit.h"
 #include <glog/logging.h>
+#include "KafkaSplit.h"
 #include "velox/vector/FlatVector.h"
 
 namespace gluten {
@@ -30,8 +30,7 @@ class KafkaEventCb : public RdKafka::EventCb {
   void event_cb(RdKafka::Event& event) override {
     switch (event.type()) {
       case RdKafka::Event::EVENT_ERROR:
-        LOG(ERROR) << "Kafka error: " << RdKafka::err2str(event.err()) 
-                   << " - " << event.str();
+        LOG(ERROR) << "Kafka error: " << RdKafka::err2str(event.err()) << " - " << event.str();
         break;
       case RdKafka::Event::EVENT_STATS:
         LOG(INFO) << "Kafka stats: " << event.str();
@@ -72,12 +71,7 @@ KafkaReader::KafkaReader(
     int32_t operatorId,
     facebook::velox::exec::DriverCtx* driverCtx,
     const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode)
-    : SourceOperator(
-          driverCtx,
-          planNode->outputType(),
-          operatorId,
-          planNode->id(),
-          "KafkaReader") {
+    : SourceOperator(driverCtx, planNode->outputType(), operatorId, planNode->id(), "KafkaReader") {
   LOG(INFO) << "KafkaReader created with operator ID: " << operatorId;
 }
 
@@ -151,7 +145,7 @@ void KafkaReader::connectToKafka() {
 
   // Create topic partition for assignment
   std::vector<RdKafka::TopicPartition*> partitions;
-  RdKafka::TopicPartition* partition = 
+  RdKafka::TopicPartition* partition =
       RdKafka::TopicPartition::create(config_.topic, config_.partition, config_.startOffset);
   partitions.push_back(partition);
 
@@ -163,8 +157,7 @@ void KafkaReader::connectToKafka() {
   }
 
   currentOffset_ = config_.startOffset;
-  LOG(INFO) << "Connected to Kafka topic: " << config_.topic 
-            << ", partition: " << config_.partition
+  LOG(INFO) << "Connected to Kafka topic: " << config_.topic << ", partition: " << config_.partition
             << ", start offset: " << config_.startOffset;
 
   delete partition;
@@ -172,25 +165,25 @@ void KafkaReader::connectToKafka() {
 
 std::vector<RdKafka::Message*> KafkaReader::pollMessages() {
   std::vector<RdKafka::Message*> messages;
-  
+
   if (!consumer_) {
     return messages;
   }
 
   int32_t remainingRecords = config_.maxPollRecords;
   auto startTime = std::chrono::steady_clock::now();
-  
+
   while (remainingRecords > 0) {
     // Check if we've exceeded the poll timeout
-    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - startTime).count();
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime).count();
     if (elapsed >= config_.pollTimeoutMs) {
       break;
     }
 
     // Poll for a single message
     RdKafka::Message* msg = consumer_->consume(100); // 100ms timeout per consume
-    
+
     if (!msg) {
       continue;
     }
@@ -202,10 +195,9 @@ std::vector<RdKafka::Message*> KafkaReader::pollMessages() {
         currentOffset_ = msg->offset();
         messagesRead_++;
         remainingRecords--;
-        
+
         // Check if we've reached the end offset
-        if (config_.endOffset != RdKafka::Topic::OFFSET_END && 
-            currentOffset_ >= config_.endOffset) {
+        if (config_.endOffset != RdKafka::Topic::OFFSET_END && currentOffset_ >= config_.endOffset) {
           finished_ = true;
           return messages;
         }
@@ -234,8 +226,7 @@ std::vector<RdKafka::Message*> KafkaReader::pollMessages() {
   return messages;
 }
 
-facebook::velox::RowVectorPtr KafkaReader::convertMessagesToRowVector(
-    const std::vector<RdKafka::Message*>& messages) {
+facebook::velox::RowVectorPtr KafkaReader::convertMessagesToRowVector(const std::vector<RdKafka::Message*>& messages) {
   if (messages.empty()) {
     return nullptr;
   }
@@ -250,11 +241,7 @@ facebook::velox::RowVectorPtr KafkaReader::convertMessagesToRowVector(
 
   // Create and return RowVector
   return std::make_shared<facebook::velox::RowVector>(
-      pool(),
-      outputType_,
-      facebook::velox::BufferPtr(nullptr),
-      numRows,
-      childVectors);
+      pool(), outputType_, facebook::velox::BufferPtr(nullptr), numRows, childVectors);
 }
 
 facebook::velox::VectorPtr KafkaReader::createColumnVector(
@@ -262,7 +249,7 @@ facebook::velox::VectorPtr KafkaReader::createColumnVector(
     const std::vector<RdKafka::Message*>& messages,
     size_t columnIndex) {
   size_t numRows = messages.size();
-  
+
   // Handle common Kafka message fields based on column index
   // Column 0: key (VARBINARY)
   // Column 1: value (VARBINARY)
@@ -274,23 +261,22 @@ facebook::velox::VectorPtr KafkaReader::createColumnVector(
   if (type->isVarbinary() || type->isVarchar()) {
     auto flatVector = std::dynamic_pointer_cast<facebook::velox::FlatVector<facebook::velox::StringView>>(
         facebook::velox::BaseVector::create(type, numRows, pool()));
-    
+
     for (size_t i = 0; i < numRows; ++i) {
       const auto* msg = messages[i];
-      
+
       if (columnIndex == 0) {
         // Key
         if (msg->key()) {
-          flatVector->set(i, facebook::velox::StringView(
-              static_cast<const char*>(msg->key()->c_str()), msg->key()->size()));
+          flatVector->set(
+              i, facebook::velox::StringView(static_cast<const char*>(msg->key()->c_str()), msg->key()->size()));
         } else {
           flatVector->setNull(i, true);
         }
       } else if (columnIndex == 1) {
         // Value
         if (msg->payload()) {
-          flatVector->set(i, facebook::velox::StringView(
-              static_cast<const char*>(msg->payload()), msg->len()));
+          flatVector->set(i, facebook::velox::StringView(static_cast<const char*>(msg->payload()), msg->len()));
         } else {
           flatVector->setNull(i, true);
         }
@@ -300,29 +286,29 @@ facebook::velox::VectorPtr KafkaReader::createColumnVector(
         flatVector->set(i, facebook::velox::StringView(topicName));
       }
     }
-    
+
     return flatVector;
   } else if (type->isInteger()) {
     auto flatVector = std::dynamic_pointer_cast<facebook::velox::FlatVector<int32_t>>(
         facebook::velox::BaseVector::create(type, numRows, pool()));
-    
+
     for (size_t i = 0; i < numRows; ++i) {
       const auto* msg = messages[i];
-      
+
       if (columnIndex == 3) {
         // Partition
         flatVector->set(i, msg->partition());
       }
     }
-    
+
     return flatVector;
   } else if (type->isBigint()) {
     auto flatVector = std::dynamic_pointer_cast<facebook::velox::FlatVector<int64_t>>(
         facebook::velox::BaseVector::create(type, numRows, pool()));
-    
+
     for (size_t i = 0; i < numRows; ++i) {
       const auto* msg = messages[i];
-      
+
       if (columnIndex == 4) {
         // Offset
         flatVector->set(i, msg->offset());
@@ -331,10 +317,10 @@ facebook::velox::VectorPtr KafkaReader::createColumnVector(
         flatVector->set(i, msg->timestamp().timestamp);
       }
     }
-    
+
     return flatVector;
   }
-  
+
   // Default: create empty vector
   return facebook::velox::BaseVector::create(type, numRows, pool());
 }
@@ -345,8 +331,7 @@ void KafkaReader::commitOffset(int64_t offset) {
   }
 
   std::vector<RdKafka::TopicPartition*> partitions;
-  RdKafka::TopicPartition* partition = 
-      RdKafka::TopicPartition::create(config_.topic, config_.partition, offset + 1);
+  RdKafka::TopicPartition* partition = RdKafka::TopicPartition::create(config_.topic, config_.partition, offset + 1);
   partitions.push_back(partition);
 
   RdKafka::ErrorCode err = consumer_->commitSync(partitions);
@@ -365,13 +350,13 @@ void KafkaReader::cleanup() {
     if (currentOffset_ > 0) {
       commitOffset(currentOffset_);
     }
-    
+
     // Close consumer
     consumer_->close();
     consumer_.reset();
     LOG(INFO) << "Kafka consumer closed. Total messages read: " << messagesRead_;
   }
-  
+
   conf_.reset();
   tconf_.reset();
 }
@@ -394,7 +379,7 @@ facebook::velox::RowVectorPtr KafkaReader::getOutput() {
 
   // Poll messages from Kafka
   auto messages = pollMessages();
-  
+
   if (messages.empty()) {
     // No messages available, but not finished yet
     if (!finished_) {
@@ -406,7 +391,7 @@ facebook::velox::RowVectorPtr KafkaReader::getOutput() {
 
   // Convert messages to RowVector
   auto result = convertMessagesToRowVector(messages);
-  
+
   // Clean up messages
   for (auto* msg : messages) {
     delete msg;
@@ -420,8 +405,7 @@ facebook::velox::RowVectorPtr KafkaReader::getOutput() {
   return result;
 }
 
-facebook::velox::exec::BlockingReason KafkaReader::isBlocked(
-    facebook::velox::ContinueFuture* future) {
+facebook::velox::exec::BlockingReason KafkaReader::isBlocked(facebook::velox::ContinueFuture* future) {
   // Kafka consumer is non-blocking with timeout
   return facebook::velox::exec::BlockingReason::kNotBlocked;
 }
@@ -430,16 +414,15 @@ bool KafkaReader::isFinished() {
   return (noMoreSplits_ && !hasSplit_) || finished_;
 }
 
-void KafkaReader::addSplit(
-    std::shared_ptr<facebook::velox::connector::ConnectorSplit> split) {
+void KafkaReader::addSplit(std::shared_ptr<facebook::velox::connector::ConnectorSplit> split) {
   // Extract Kafka configuration from split
   auto kafkaSplit = std::dynamic_pointer_cast<const KafkaConnectorSplit>(split);
   if (!kafkaSplit) {
     throw std::runtime_error("Split is not a KafkaConnectorSplit");
   }
-  
+
   hasSplit_ = true;
-  
+
   // Populate config from split
   config_.brokers = kafkaSplit->getBrokers();
   config_.topic = kafkaSplit->getTopic();
@@ -448,7 +431,7 @@ void KafkaReader::addSplit(
   config_.endOffset = kafkaSplit->getEndOffset();
   config_.groupId = kafkaSplit->getGroupId();
   config_.additionalProps = kafkaSplit->getAdditionalProps();
-  
+
   LOG(INFO) << "Added Kafka split: " << kafkaSplit->toString();
 }
 

--- a/cpp/velox/operators/reader/KafkaReader.h
+++ b/cpp/velox/operators/reader/KafkaReader.h
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <librdkafka/rdkafkacpp.h>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "velox/connectors/Connector.h"
+#include "velox/exec/Operator.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace gluten {
+
+/// Configuration for Kafka consumer
+struct KafkaReaderConfig {
+  std::string brokers;
+  std::string topic;
+  int32_t partition;
+  int64_t startOffset;
+  int64_t endOffset;
+  std::string groupId;
+  int32_t maxPollRecords;
+  int32_t pollTimeoutMs;
+  std::unordered_map<std::string, std::string> additionalProps;
+
+  KafkaReaderConfig()
+      : partition(0),
+        startOffset(RdKafka::Topic::OFFSET_BEGINNING),
+        endOffset(RdKafka::Topic::OFFSET_END),
+        maxPollRecords(1000),
+        pollTimeoutMs(1000) {}
+};
+
+/// Kafka reader operator for streaming Kafka data
+/// Integrates with librdkafka to consume messages from Kafka topics
+class KafkaReader : public facebook::velox::exec::SourceOperator {
+ public:
+  KafkaReader(
+      int32_t operatorId,
+      facebook::velox::exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode);
+
+  ~KafkaReader() override;
+
+  facebook::velox::RowVectorPtr getOutput() override;
+
+  facebook::velox::exec::BlockingReason isBlocked(
+      facebook::velox::ContinueFuture* future) override;
+
+  bool isFinished() override;
+
+  void addSplit(std::shared_ptr<facebook::velox::connector::ConnectorSplit> split);
+
+  void noMoreSplits();
+
+ private:
+  /// Initialize Kafka consumer with configuration
+  void initializeConsumer();
+
+  /// Connect to Kafka broker and subscribe to topic/partition
+  void connectToKafka();
+
+  /// Poll messages from Kafka
+  std::vector<RdKafka::Message*> pollMessages();
+
+  /// Convert Kafka messages to RowVector format
+  facebook::velox::RowVectorPtr convertMessagesToRowVector(
+      const std::vector<RdKafka::Message*>& messages);
+
+  /// Handle offset management
+  void commitOffset(int64_t offset);
+
+  /// Cleanup Kafka resources
+  void cleanup();
+
+  /// Create vector for a specific column based on type
+  facebook::velox::VectorPtr createColumnVector(
+      const facebook::velox::TypePtr& type,
+      const std::vector<RdKafka::Message*>& messages,
+      size_t columnIndex);
+
+  // Kafka consumer and configuration
+  std::unique_ptr<RdKafka::KafkaConsumer> consumer_;
+  std::unique_ptr<RdKafka::Conf> conf_;
+  std::unique_ptr<RdKafka::Conf> tconf_;
+  KafkaReaderConfig config_;
+
+  // State management
+  bool noMoreSplits_ = false;
+  bool hasSplit_ = false;
+  bool consumerInitialized_ = false;
+  bool finished_ = false;
+  int64_t currentOffset_ = 0;
+  int64_t messagesRead_ = 0;
+
+  // Buffer for batching
+  std::vector<RdKafka::Message*> messageBuffer_;
+  size_t maxBatchSize_ = 1000;
+};
+
+} // namespace gluten

--- a/cpp/velox/operators/reader/KafkaReader.h
+++ b/cpp/velox/operators/reader/KafkaReader.h
@@ -60,8 +60,7 @@ class KafkaReader : public facebook::velox::exec::SourceOperator {
 
   facebook::velox::RowVectorPtr getOutput() override;
 
-  facebook::velox::exec::BlockingReason isBlocked(
-      facebook::velox::ContinueFuture* future) override;
+  facebook::velox::exec::BlockingReason isBlocked(facebook::velox::ContinueFuture* future) override;
 
   bool isFinished() override;
 
@@ -80,8 +79,7 @@ class KafkaReader : public facebook::velox::exec::SourceOperator {
   std::vector<RdKafka::Message*> pollMessages();
 
   /// Convert Kafka messages to RowVector format
-  facebook::velox::RowVectorPtr convertMessagesToRowVector(
-      const std::vector<RdKafka::Message*>& messages);
+  facebook::velox::RowVectorPtr convertMessagesToRowVector(const std::vector<RdKafka::Message*>& messages);
 
   /// Handle offset management
   void commitOffset(int64_t offset);

--- a/cpp/velox/operators/reader/KafkaSplit.h
+++ b/cpp/velox/operators/reader/KafkaSplit.h
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "velox/connectors/Connector.h"
+
+namespace gluten {
+
+/// Split for Kafka streaming data
+/// Contains all necessary information to connect to and consume from a Kafka topic/partition
+class KafkaConnectorSplit : public facebook::velox::connector::ConnectorSplit {
+ public:
+  KafkaConnectorSplit(
+      const std::string& connectorId,
+      const std::string& brokers,
+      const std::string& topic,
+      int32_t partition,
+      int64_t startOffset,
+      int64_t endOffset,
+      const std::string& groupId = "",
+      const std::unordered_map<std::string, std::string>& additionalProps = {})
+      : ConnectorSplit(connectorId),
+        brokers_(brokers),
+        topic_(topic),
+        partition_(partition),
+        startOffset_(startOffset),
+        endOffset_(endOffset),
+        groupId_(groupId),
+        additionalProps_(additionalProps) {}
+
+  const std::string& getBrokers() const {
+    return brokers_;
+  }
+
+  const std::string& getTopic() const {
+    return topic_;
+  }
+
+  int32_t getPartition() const {
+    return partition_;
+  }
+
+  int64_t getStartOffset() const {
+    return startOffset_;
+  }
+
+  int64_t getEndOffset() const {
+    return endOffset_;
+  }
+
+  const std::string& getGroupId() const {
+    return groupId_;
+  }
+
+  const std::unordered_map<std::string, std::string>& getAdditionalProps() const {
+    return additionalProps_;
+  }
+
+  std::string toString() const override {
+    return fmt::format(
+        "KafkaConnectorSplit[brokers={}, topic={}, partition={}, startOffset={}, endOffset={}]",
+        brokers_,
+        topic_,
+        partition_,
+        startOffset_,
+        endOffset_);
+  }
+
+ private:
+  std::string brokers_;
+  std::string topic_;
+  int32_t partition_;
+  int64_t startOffset_;
+  int64_t endOffset_;
+  std::string groupId_;
+  std::unordered_map<std::string, std::string> additionalProps_;
+};
+
+} // namespace gluten
+
+// Made with Bob

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1483,6 +1483,69 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::constructCudfValueStreamNode(
 }
 #endif
 
+#ifdef ENABLE_KAFKA
+core::PlanNodePtr SubstraitToVeloxPlanConverter::constructKafkaStreamNode(
+    const ::substrait::ReadRel& readRel) {
+  // Get output schema from ReadRel
+  std::vector<std::string> colNameList;
+  std::vector<TypePtr> veloxTypeList;
+  bool asLowerCase = !veloxCfg_->get<bool>(kCaseSensitive, false);
+  
+  if (readRel.has_base_schema()) {
+    const auto& baseSchema = readRel.base_schema();
+    colNameList.reserve(baseSchema.names().size());
+    for (const auto& name : baseSchema.names()) {
+      std::string fieldName = name;
+      if (asLowerCase) {
+        folly::toLowerAscii(fieldName);
+      }
+      colNameList.emplace_back(fieldName);
+    }
+    veloxTypeList = SubstraitParser::parseNamedStruct(baseSchema, asLowerCase);
+  }
+
+  // Create output names for the plan node
+  std::vector<std::string> outNames;
+  outNames.reserve(colNameList.size());
+  connector::ColumnHandleMap assignments;
+  
+  for (int idx = 0; idx < colNameList.size(); idx++) {
+    auto outName = SubstraitParser::makeNodeName(planNodeId_, idx);
+    assignments[outName] = std::make_shared<connector::hive::HiveColumnHandle>(
+        colNameList[idx], 
+        connector::hive::HiveColumnHandle::ColumnType::kRegular,
+        veloxTypeList[idx], 
+        veloxTypeList[idx]);
+    outNames.emplace_back(outName);
+  }
+  
+  auto outputType = ROW(std::move(outNames), std::move(veloxTypeList));
+
+  // Create Kafka table handle
+  common::SubfieldFilters subfieldFilters;
+  auto tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
+      connectorIds_.kafka,
+      "kafka_stream", 
+      std::move(subfieldFilters), 
+      nullptr,  // remainingFilter
+      outputType);
+
+  // Create TableScanNode for Kafka
+  auto tableScanNode = std::make_shared<core::TableScanNode>(
+      nextPlanNodeId(), 
+      std::move(outputType), 
+      std::move(tableHandle), 
+      assignments);
+
+  // Set split info for Kafka stream
+  auto splitInfo = std::make_shared<SplitInfo>();
+  splitInfo->leafType = SplitInfo::LeafType::TABLE_SCAN;
+  splitInfoMap_[tableScanNode->id()] = splitInfo;
+
+  return tableScanNode;
+}
+#endif
+
 core::PlanNodePtr SubstraitToVeloxPlanConverter::constructValuesNode(
     const ::substrait::ReadRel& readRel,
     int32_t streamIdx) {
@@ -1509,6 +1572,15 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   if (readRel.has_common()) {
     VELOX_USER_CHECK(
         !readRel.common().has_emit(), "Emit not supported for ValuesNode and TableScanNode related Substrait plans.");
+  }
+
+  // Check if this is a Kafka stream - handle it specially
+  if (readRel.stream_kafka()) {
+#ifdef ENABLE_KAFKA
+    return constructKafkaStreamNode(readRel);
+#else
+    VELOX_USER_FAIL("The plan contains a Kafka read, but Gluten was built without ENABLE_KAFKA.");
+#endif
   }
 
   auto streamIdx = getStreamIndex(readRel);
@@ -1777,6 +1849,13 @@ std::string SubstraitToVeloxPlanConverter::findFuncSpec(uint64_t id) {
 }
 
 int32_t SubstraitToVeloxPlanConverter::getStreamIndex(const ::substrait::ReadRel& sRead) {
+  // Check if this is a Kafka stream
+  if (sRead.stream_kafka()) {
+    // For Kafka streams, we don't use the iterator pattern
+    // Return -1 to indicate this should be handled as a regular scan
+    return -1;
+  }
+  
   if (sRead.has_local_files()) {
     const auto& fileList = sRead.local_files().items();
     if (fileList.size() == 0) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1484,13 +1484,12 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::constructCudfValueStreamNode(
 #endif
 
 #ifdef ENABLE_KAFKA
-core::PlanNodePtr SubstraitToVeloxPlanConverter::constructKafkaStreamNode(
-    const ::substrait::ReadRel& readRel) {
+core::PlanNodePtr SubstraitToVeloxPlanConverter::constructKafkaStreamNode(const ::substrait::ReadRel& readRel) {
   // Get output schema from ReadRel
   std::vector<std::string> colNameList;
   std::vector<TypePtr> veloxTypeList;
   bool asLowerCase = !veloxCfg_->get<bool>(kCaseSensitive, false);
-  
+
   if (readRel.has_base_schema()) {
     const auto& baseSchema = readRel.base_schema();
     colNameList.reserve(baseSchema.names().size());
@@ -1508,34 +1507,31 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::constructKafkaStreamNode(
   std::vector<std::string> outNames;
   outNames.reserve(colNameList.size());
   connector::ColumnHandleMap assignments;
-  
+
   for (int idx = 0; idx < colNameList.size(); idx++) {
     auto outName = SubstraitParser::makeNodeName(planNodeId_, idx);
     assignments[outName] = std::make_shared<connector::hive::HiveColumnHandle>(
-        colNameList[idx], 
+        colNameList[idx],
         connector::hive::HiveColumnHandle::ColumnType::kRegular,
-        veloxTypeList[idx], 
+        veloxTypeList[idx],
         veloxTypeList[idx]);
     outNames.emplace_back(outName);
   }
-  
+
   auto outputType = ROW(std::move(outNames), std::move(veloxTypeList));
 
   // Create Kafka table handle
   common::SubfieldFilters subfieldFilters;
   auto tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
       connectorIds_.kafka,
-      "kafka_stream", 
-      std::move(subfieldFilters), 
-      nullptr,  // remainingFilter
+      "kafka_stream",
+      std::move(subfieldFilters),
+      nullptr, // remainingFilter
       outputType);
 
   // Create TableScanNode for Kafka
   auto tableScanNode = std::make_shared<core::TableScanNode>(
-      nextPlanNodeId(), 
-      std::move(outputType), 
-      std::move(tableHandle), 
-      assignments);
+      nextPlanNodeId(), std::move(outputType), std::move(tableHandle), assignments);
 
   // Set split info for Kafka stream
   auto splitInfo = std::make_shared<SplitInfo>();
@@ -1855,7 +1851,7 @@ int32_t SubstraitToVeloxPlanConverter::getStreamIndex(const ::substrait::ReadRel
     // Return -1 to indicate this should be handled as a regular scan
     return -1;
   }
-  
+
   if (sRead.has_local_files()) {
     const auto& fileList = sRead.local_files().items();
     if (fileList.size() == 0) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -153,6 +153,9 @@ class SubstraitToVeloxPlanConverter {
   // Construct a cuDF value stream node.
   core::PlanNodePtr constructCudfValueStreamNode(const ::substrait::ReadRel& sRead, int32_t streamIdx);
 
+  // Construct a Kafka stream node for reading from Kafka topics.
+  core::PlanNodePtr constructKafkaStreamNode(const ::substrait::ReadRel& sRead);
+
   // This is only used in benchmark and enable query trace, which will load all the data to ValuesNode.
   core::PlanNodePtr constructValuesNode(const ::substrait::ReadRel& sRead, int32_t streamIdx);
 

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -36,6 +36,7 @@ ENABLE_GCS=OFF
 ENABLE_S3=OFF
 ENABLE_HDFS=OFF
 ENABLE_ABFS=OFF
+ENABLE_KAFKA=OFF
 ENABLE_VCPKG=OFF
 ENABLE_GPU=OFF
 ENABLE_ENHANCED_FEATURES=OFF
@@ -101,6 +102,10 @@ do
         ;;
         --enable_abfs=*)
         ENABLE_ABFS=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --enable_kafka=*)
+        ENABLE_KAFKA=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
         --enable_vcpkg=*)
@@ -200,7 +205,7 @@ function concat_velox_param {
 if [ "$ENABLE_VCPKG" = "ON" ]; then
     # vcpkg will install static depends and init build environment
     BUILD_OPTIONS="--build_tests=$BUILD_TESTS --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS \
-                   --enable_hdfs=$ENABLE_HDFS --enable_abfs=$ENABLE_ABFS"
+                   --enable_hdfs=$ENABLE_HDFS --enable_abfs=$ENABLE_ABFS --enable_kafka=$ENABLE_KAFKA"
     source ./dev/vcpkg/env.sh ${BUILD_OPTIONS}
 fi
 
@@ -267,6 +272,7 @@ function build_gluten_cpp {
     "-DENABLE_S3=$ENABLE_S3"
     "-DENABLE_HDFS=$ENABLE_HDFS"
     "-DENABLE_ABFS=$ENABLE_ABFS"
+    "-DENABLE_KAFKA=$ENABLE_KAFKA"
     "-DENABLE_GPU=$ENABLE_GPU"
     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
     "-DENABLE_ENHANCED_FEATURES=$ENABLE_ENHANCED_FEATURES"

--- a/dev/vcpkg/init.sh
+++ b/dev/vcpkg/init.sh
@@ -22,6 +22,7 @@ ENABLE_S3=OFF
 ENABLE_GCS=OFF
 ENABLE_HDFS=OFF
 ENABLE_ABFS=OFF
+ENABLE_KAFKA=OFF
 
 for arg in "$@"; do
   case $arg in
@@ -43,6 +44,10 @@ for arg in "$@"; do
     ;;
   --enable_abfs=*)
     ENABLE_ABFS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_kafka=*)
+    ENABLE_KAFKA=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
   *)
@@ -86,6 +91,9 @@ if [ "$ENABLE_GCS" = "ON" ]; then
 fi
 if [ "$ENABLE_ABFS" = "ON" ]; then
   EXTRA_FEATURES+="--x-feature=velox-abfs "
+fi
+if [ "$ENABLE_KAFKA" = "ON" ]; then
+  EXTRA_FEATURES+="--x-feature=velox-kafka "
 fi
 if [ "${VCPKG_DYNAMIC_OPENSSL:-OFF}" = "ON" ]; then
   EXTRA_FEATURES+="--x-feature=dynamic-openssl "

--- a/dev/vcpkg/vcpkg.json
+++ b/dev/vcpkg/vcpkg.json
@@ -99,6 +99,12 @@
         "azure-identity-cpp"
       ]
     },
+    "velox-kafka": {
+      "description": "Velox Kafka Support",
+      "dependencies": [
+        "librdkafka"
+      ]
+    },
     "duckdb": {
       "description": "DUCKDB",
       "dependencies": [

--- a/docs/get-started/build-guide.md
+++ b/docs/get-started/build-guide.md
@@ -20,6 +20,7 @@ Please set them via `--`, e.g. `--build_type=Release`.
 | enable_gcs             | Build with GCS support.                                                                       | OFF     |
 | enable_hdfs            | Build with HDFS support.                                                                      | OFF     |
 | enable_abfs            | Build with ABFS support.                                                                      | OFF     |
+| enable_kafka           | Build with Kafka streaming read support (librdkafka).                                        | OFF     |
 | enable_vcpkg           | Enable vcpkg for static build.                                                                | OFF     |
 | run_setup_script       | Run setup script to install Velox dependencies.                                               | ON      |
 | velox_repo             | Specify your own Velox repo to build.                                                         | ""      |


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Add an opt-in Kafka read path to the Velox backend, allowing Substrait plans carrying ReadRel.stream_kafka to be executed as a table scan over a Kafka topic/partition via librdkafka.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
